### PR TITLE
[4.7] Cgroup v1 removal nits/fixes

### DIFF
--- a/libcontainer/cgroups/fs/fs.go
+++ b/libcontainer/cgroups/fs/fs.go
@@ -233,11 +233,7 @@ func (m *manager) Destroy() error {
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if err := cgroups.RemovePaths(m.paths); err != nil {
-		return err
-	}
-	m.paths = make(map[string]string)
-	return nil
+	return cgroups.RemovePaths(m.paths)
 }
 
 func (m *manager) Path(subsys string) string {

--- a/libcontainer/cgroups/systemd/v1.go
+++ b/libcontainer/cgroups/systemd/v1.go
@@ -223,17 +223,14 @@ func (m *legacyManager) Destroy() error {
 	}
 	unitName := getUnitName(m.cgroups)
 
-	err = stopUnit(dbusConnection, unitName)
+	stopErr := stopUnit(dbusConnection, unitName)
 	// Both on success and on error, cleanup all the cgroups we are aware of.
 	// Some of them were created directly by Apply() and are not managed by systemd.
 	if err := cgroups.RemovePaths(m.paths); err != nil {
 		return err
 	}
-	if err != nil {
-		return err
-	}
-	m.paths = make(map[string]string)
-	return nil
+
+	return stopErr
 }
 
 func (m *legacyManager) Path(subsys string) string {

--- a/libcontainer/cgroups/utils.go
+++ b/libcontainer/cgroups/utils.go
@@ -230,6 +230,7 @@ func RemovePaths(paths map[string]string) (err error) {
 			}
 		}
 		if len(paths) == 0 {
+			paths = make(map[string]string)
 			return nil
 		}
 	}

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -286,6 +286,11 @@ function requires() {
 				skip_me=1
 			fi
 			;;
+		cgroupns)
+			if [ ! -e "/proc/self/ns/cgroup" ]; then
+				skip_me=1
+			fi
+			;;
 		cgroups_v1)
 			init_cgroup_paths
 			if [ "$CGROUP_UNIFIED" != "no" ]; then


### PR DESCRIPTION
This is a backport of https://github.com/opencontainers/runc/pull/2506 to a runc version currently used by openshift/kubernetes master. For more info, see the above PR and/or individual commits.

For one thing, this adds logging to unsuccessful cgroup removal attempts.