### PR TITLE
[4.6] libct/cg/sd: reconnect and retry on dbus connection error

### DIFF
--- a/libcontainer/cgroups/systemd/common.go
+++ b/libcontainer/cgroups/systemd/common.go
@@ -310,9 +310,13 @@ func isUnitExists(err error) bool {
 	return isDbusError(err, "org.freedesktop.systemd1.UnitExists")
 }
 
-func startUnit(dbusConnection *systemdDbus.Conn, unitName string, properties []systemdDbus.Property) error {
+func startUnit(cm *dbusConnManager, unitName string, properties []systemdDbus.Property) error {
 	statusChan := make(chan string, 1)
-	if _, err := dbusConnection.StartTransientUnit(unitName, "replace", properties, statusChan); err == nil {
+	err := cm.retryOnDisconnect(func(c *systemdDbus.Conn) error {
+		_, err := c.StartTransientUnit(unitName, "replace", properties, statusChan)
+		return err
+	})
+	if err == nil {
 		timeout := time.NewTimer(30 * time.Second)
 		defer timeout.Stop()
 
@@ -321,11 +325,11 @@ func startUnit(dbusConnection *systemdDbus.Conn, unitName string, properties []s
 			close(statusChan)
 			// Please refer to https://godoc.org/github.com/coreos/go-systemd/dbus#Conn.StartUnit
 			if s != "done" {
-				dbusConnection.ResetFailedUnit(unitName)
+				resetFailedUnit(cm, unitName)
 				return errors.Errorf("error creating systemd unit `%s`: got `%s`", unitName, s)
 			}
 		case <-timeout.C:
-			dbusConnection.ResetFailedUnit(unitName)
+			resetFailedUnit(cm, unitName)
 			return errors.New("Timeout waiting for systemd to create " + unitName)
 		}
 	} else if !isUnitExists(err) {
@@ -335,9 +339,13 @@ func startUnit(dbusConnection *systemdDbus.Conn, unitName string, properties []s
 	return nil
 }
 
-func stopUnit(dbusConnection *systemdDbus.Conn, unitName string) error {
+func stopUnit(cm *dbusConnManager, unitName string) error {
 	statusChan := make(chan string, 1)
-	if _, err := dbusConnection.StopUnit(unitName, "replace", statusChan); err == nil {
+	err := cm.retryOnDisconnect(func(c *systemdDbus.Conn) error {
+		_, err := c.StopUnit(unitName, "replace", statusChan)
+		return err
+	})
+	if err == nil {
 		select {
 		case s := <-statusChan:
 			close(statusChan)
@@ -352,10 +360,30 @@ func stopUnit(dbusConnection *systemdDbus.Conn, unitName string) error {
 	return nil
 }
 
-func systemdVersion(conn *systemdDbus.Conn) int {
+func resetFailedUnit(cm *dbusConnManager, name string) {
+	err := cm.retryOnDisconnect(func(c *systemdDbus.Conn) error {
+		return c.ResetFailedUnit(name)
+	})
+	if err != nil {
+		logrus.Warnf("unable to reset failed unit: %v", err)
+	}
+}
+
+func setUnitProperties(cm *dbusConnManager, name string, properties ...systemdDbus.Property) error {
+	return cm.retryOnDisconnect(func(c *systemdDbus.Conn) error {
+		return c.SetUnitProperties(name, true, properties...)
+	})
+}
+
+func systemdVersion(cm *dbusConnManager) int {
 	versionOnce.Do(func() {
 		version = -1
-		verStr, err := conn.GetManagerProperty("Version")
+		var verStr string
+		err := cm.retryOnDisconnect(func(c *systemdDbus.Conn) error {
+			var err error
+			verStr, err = c.GetManagerProperty("Version")
+			return err
+		})
 		if err == nil {
 			version, err = systemdVersionAtoi(verStr)
 		}
@@ -383,10 +411,10 @@ func systemdVersionAtoi(verStr string) (int, error) {
 	return ver, errors.Wrapf(err, "can't parse version %s", verStr)
 }
 
-func addCpuQuota(conn *systemdDbus.Conn, properties *[]systemdDbus.Property, quota int64, period uint64) {
+func addCpuQuota(cm *dbusConnManager, properties *[]systemdDbus.Property, quota int64, period uint64) {
 	if period != 0 {
 		// systemd only supports CPUQuotaPeriodUSec since v242
-		sdVer := systemdVersion(conn)
+		sdVer := systemdVersion(cm)
 		if sdVer >= 242 {
 			*properties = append(*properties,
 				newProp("CPUQuotaPeriodUSec", period))

--- a/libcontainer/cgroups/systemd/common.go
+++ b/libcontainer/cgroups/systemd/common.go
@@ -20,10 +20,6 @@ import (
 )
 
 var (
-	connOnce sync.Once
-	connDbus *systemdDbus.Conn
-	connErr  error
-
 	versionOnce sync.Once
 	version     int
 
@@ -281,19 +277,6 @@ func generateDeviceProperties(rules []*configs.DeviceRule) ([]systemdDbus.Proper
 
 	properties = append(properties, newProp("DeviceAllow", deviceAllowList))
 	return properties, nil
-}
-
-// getDbusConnection lazy initializes systemd dbus connection
-// and returns it
-func getDbusConnection(rootless bool) (*systemdDbus.Conn, error) {
-	connOnce.Do(func() {
-		if rootless {
-			connDbus, connErr = NewUserSystemdDbus()
-		} else {
-			connDbus, connErr = systemdDbus.New()
-		}
-	})
-	return connDbus, connErr
 }
 
 func newProp(name string, units interface{}) systemdDbus.Property {

--- a/libcontainer/cgroups/systemd/common.go
+++ b/libcontainer/cgroups/systemd/common.go
@@ -26,7 +26,6 @@ var (
 
 	versionOnce sync.Once
 	version     int
-	versionErr  error
 
 	isRunningSystemdOnce sync.Once
 	isRunningSystemd     bool
@@ -364,20 +363,20 @@ func stopUnit(dbusConnection *systemdDbus.Conn, unitName string) error {
 	return nil
 }
 
-func systemdVersion(conn *systemdDbus.Conn) (int, error) {
+func systemdVersion(conn *systemdDbus.Conn) int {
 	versionOnce.Do(func() {
 		version = -1
 		verStr, err := conn.GetManagerProperty("Version")
-		if err != nil {
-			versionErr = err
-			return
+		if err == nil {
+			version, err = systemdVersionAtoi(verStr)
 		}
 
-		version, versionErr = systemdVersionAtoi(verStr)
-		return
+		if err != nil {
+			logrus.WithError(err).Error("unable to get systemd version")
+		}
 	})
 
-	return version, versionErr
+	return version
 }
 
 func systemdVersionAtoi(verStr string) (int, error) {
@@ -398,10 +397,8 @@ func systemdVersionAtoi(verStr string) (int, error) {
 func addCpuQuota(conn *systemdDbus.Conn, properties *[]systemdDbus.Property, quota int64, period uint64) {
 	if period != 0 {
 		// systemd only supports CPUQuotaPeriodUSec since v242
-		sdVer, err := systemdVersion(conn)
-		if err != nil {
-			logrus.Warnf("systemdVersion: %s", err)
-		} else if sdVer >= 242 {
+		sdVer := systemdVersion(conn)
+		if sdVer >= 242 {
 			*properties = append(*properties,
 				newProp("CPUQuotaPeriodUSec", period))
 		}

--- a/libcontainer/cgroups/systemd/common.go
+++ b/libcontainer/cgroups/systemd/common.go
@@ -375,15 +375,23 @@ func setUnitProperties(cm *dbusConnManager, name string, properties ...systemdDb
 	})
 }
 
+func getManagerProperty(cm *dbusConnManager, name string) (string, error) {
+	str := ""
+	err := cm.retryOnDisconnect(func(c *systemdDbus.Conn) error {
+		var err error
+		str, err = c.GetManagerProperty(name)
+		return err
+	})
+	if err != nil {
+		return "", err
+	}
+	return strconv.Unquote(str)
+}
+
 func systemdVersion(cm *dbusConnManager) int {
 	versionOnce.Do(func() {
 		version = -1
-		var verStr string
-		err := cm.retryOnDisconnect(func(c *systemdDbus.Conn) error {
-			var err error
-			verStr, err = c.GetManagerProperty("Version")
-			return err
-		})
+		verStr, err := getManagerProperty(cm, "Version")
 		if err == nil {
 			version, err = systemdVersionAtoi(verStr)
 		}
@@ -398,11 +406,11 @@ func systemdVersion(cm *dbusConnManager) int {
 
 func systemdVersionAtoi(verStr string) (int, error) {
 	// verStr should be of the form:
-	// "v245.4-1.fc32", "245", "v245-1.fc32", "245-1.fc32"
-	// all the input strings include quotes, and the output int should be 245
-	// thus, we unconditionally remove the `"v`
-	// and then match on the first integer we can grab
-	re := regexp.MustCompile(`"?v?([0-9]+)`)
+	// "v245.4-1.fc32", "245", "v245-1.fc32", "245-1.fc32" (without quotes).
+	// The result for all of the above should be 245.
+	// Thus, we unconditionally remove the "v" prefix
+	// and then match on the first integer we can grab.
+	re := regexp.MustCompile(`v?([0-9]+)`)
 	matches := re.FindStringSubmatch(verStr)
 	if len(matches) < 2 {
 		return 0, errors.Errorf("can't parse version %s: incorrect number of matches %v", verStr, matches)

--- a/libcontainer/cgroups/systemd/common.go
+++ b/libcontainer/cgroups/systemd/common.go
@@ -294,14 +294,20 @@ func getUnitName(c *configs.Cgroup) string {
 	return c.Name
 }
 
-// isUnitExists returns true if the error is that a systemd unit already exists.
-func isUnitExists(err error) bool {
+// isDbusError returns true if the error is a specific dbus error.
+func isDbusError(err error, name string) bool {
 	if err != nil {
-		if dbusError, ok := err.(dbus.Error); ok {
-			return strings.Contains(dbusError.Name, "org.freedesktop.systemd1.UnitExists")
+		var derr *dbus.Error
+		if errors.As(err, &derr) {
+			return strings.Contains(derr.Name, name)
 		}
 	}
 	return false
+}
+
+// isUnitExists returns true if the error is that a systemd unit already exists.
+func isUnitExists(err error) bool {
+	return isDbusError(err, "org.freedesktop.systemd1.UnitExists")
 }
 
 func startUnit(dbusConnection *systemdDbus.Conn, unitName string, properties []systemdDbus.Property) error {

--- a/libcontainer/cgroups/systemd/dbus.go
+++ b/libcontainer/cgroups/systemd/dbus.go
@@ -7,7 +7,6 @@ import (
 
 	systemdDbus "github.com/coreos/go-systemd/v22/dbus"
 	dbus "github.com/godbus/dbus/v5"
-	"github.com/sirupsen/logrus"
 )
 
 type dbusConnManager struct {
@@ -72,17 +71,19 @@ func (d *dbusConnManager) resetConnection(conn *systemdDbus.Conn) {
 
 var errDbusConnClosed = dbus.ErrClosed.Error()
 
-// checkAndReconnect checks if the connection is disconnected,
-// and tries reconnect if it is.
-func (d *dbusConnManager) checkAndReconnect(conn *systemdDbus.Conn, err error) {
-	if !isDbusError(err, errDbusConnClosed) {
-		return
-	}
-	d.resetConnection(conn)
-
-	// Try to reconnect
-	_, err = d.getConnection()
-	if err != nil {
-		logrus.Warnf("Dbus disconnected and failed to reconnect: %s", err)
+// retryOnDisconnect calls op, and if the error it returns is about closed dbus
+// connection, the connection is re-established and the op is retried. This helps
+// with the situation when dbus is restarted and we have a stale connection.
+func (d *dbusConnManager) retryOnDisconnect(op func(*systemdDbus.Conn) error) error {
+	for {
+		conn, err := d.getConnection()
+		if err != nil {
+			return err
+		}
+		err = op(conn)
+		if !isDbusError(err, errDbusConnClosed) {
+			return err
+		}
+		d.resetConnection(conn)
 	}
 }

--- a/libcontainer/cgroups/systemd/dbus.go
+++ b/libcontainer/cgroups/systemd/dbus.go
@@ -54,7 +54,7 @@ func (d *dbusConnManager) getConnection() (*systemdDbus.Conn, error) {
 
 func (d *dbusConnManager) newConnection() (*systemdDbus.Conn, error) {
 	if d.rootless {
-		return NewUserSystemdDbus()
+		return newUserSystemdDbus()
 	}
 	return systemdDbus.New()
 }

--- a/libcontainer/cgroups/systemd/dbus.go
+++ b/libcontainer/cgroups/systemd/dbus.go
@@ -9,37 +9,43 @@ import (
 	dbus "github.com/godbus/dbus/v5"
 )
 
+var (
+	dbusC        *systemdDbus.Conn
+	dbusMu       sync.RWMutex
+	dbusInited   bool
+	dbusRootless bool
+)
+
 type dbusConnManager struct {
-	conn     *systemdDbus.Conn
-	rootless bool
-	sync.RWMutex
 }
 
 // newDbusConnManager initializes systemd dbus connection manager.
 func newDbusConnManager(rootless bool) *dbusConnManager {
-	return &dbusConnManager{
-		rootless: rootless,
+	if dbusInited && rootless != dbusRootless {
+		panic("can't have both root and rootless dbus")
 	}
+	dbusRootless = rootless
+	return &dbusConnManager{}
 }
 
 // getConnection lazily initializes and returns systemd dbus connection.
 func (d *dbusConnManager) getConnection() (*systemdDbus.Conn, error) {
-	// In the case where d.conn != nil
+	// In the case where dbusC != nil
 	// Use the read lock the first time to ensure
 	// that Conn can be acquired at the same time.
-	d.RLock()
-	if conn := d.conn; conn != nil {
-		d.RUnlock()
+	dbusMu.RLock()
+	if conn := dbusC; conn != nil {
+		dbusMu.RUnlock()
 		return conn, nil
 	}
-	d.RUnlock()
+	dbusMu.RUnlock()
 
-	// In the case where d.conn == nil
+	// In the case where dbusC == nil
 	// Use write lock to ensure that only one
 	// will be created
-	d.Lock()
-	defer d.Unlock()
-	if conn := d.conn; conn != nil {
+	dbusMu.Lock()
+	defer dbusMu.Unlock()
+	if conn := dbusC; conn != nil {
 		return conn, nil
 	}
 
@@ -47,12 +53,12 @@ func (d *dbusConnManager) getConnection() (*systemdDbus.Conn, error) {
 	if err != nil {
 		return nil, err
 	}
-	d.conn = conn
+	dbusC = conn
 	return conn, nil
 }
 
 func (d *dbusConnManager) newConnection() (*systemdDbus.Conn, error) {
-	if d.rootless {
+	if dbusRootless {
 		return newUserSystemdDbus()
 	}
 	return systemdDbus.New()
@@ -61,11 +67,11 @@ func (d *dbusConnManager) newConnection() (*systemdDbus.Conn, error) {
 // resetConnection resets the connection to its initial state
 // (so it can be reconnected if necessary).
 func (d *dbusConnManager) resetConnection(conn *systemdDbus.Conn) {
-	d.Lock()
-	defer d.Unlock()
-	if d.conn != nil && d.conn == conn {
-		d.conn.Close()
-		d.conn = nil
+	dbusMu.Lock()
+	defer dbusMu.Unlock()
+	if dbusC != nil && dbusC == conn {
+		dbusC.Close()
+		dbusC = nil
 	}
 }
 

--- a/libcontainer/cgroups/systemd/dbus.go
+++ b/libcontainer/cgroups/systemd/dbus.go
@@ -1,0 +1,88 @@
+// +build linux
+
+package systemd
+
+import (
+	"sync"
+
+	systemdDbus "github.com/coreos/go-systemd/v22/dbus"
+	dbus "github.com/godbus/dbus/v5"
+	"github.com/sirupsen/logrus"
+)
+
+type dbusConnManager struct {
+	conn     *systemdDbus.Conn
+	rootless bool
+	sync.RWMutex
+}
+
+// newDbusConnManager initializes systemd dbus connection manager.
+func newDbusConnManager(rootless bool) *dbusConnManager {
+	return &dbusConnManager{
+		rootless: rootless,
+	}
+}
+
+// getConnection lazily initializes and returns systemd dbus connection.
+func (d *dbusConnManager) getConnection() (*systemdDbus.Conn, error) {
+	// In the case where d.conn != nil
+	// Use the read lock the first time to ensure
+	// that Conn can be acquired at the same time.
+	d.RLock()
+	if conn := d.conn; conn != nil {
+		d.RUnlock()
+		return conn, nil
+	}
+	d.RUnlock()
+
+	// In the case where d.conn == nil
+	// Use write lock to ensure that only one
+	// will be created
+	d.Lock()
+	defer d.Unlock()
+	if conn := d.conn; conn != nil {
+		return conn, nil
+	}
+
+	conn, err := d.newConnection()
+	if err != nil {
+		return nil, err
+	}
+	d.conn = conn
+	return conn, nil
+}
+
+func (d *dbusConnManager) newConnection() (*systemdDbus.Conn, error) {
+	if d.rootless {
+		return NewUserSystemdDbus()
+	}
+	return systemdDbus.New()
+}
+
+// resetConnection resets the connection to its initial state
+// (so it can be reconnected if necessary).
+func (d *dbusConnManager) resetConnection(conn *systemdDbus.Conn) {
+	d.Lock()
+	defer d.Unlock()
+	if d.conn != nil && d.conn == conn {
+		d.conn.Close()
+		d.conn = nil
+	}
+}
+
+var errDbusConnClosed = dbus.ErrClosed.Error()
+
+// checkAndReconnect checks if the connection is disconnected,
+// and tries reconnect if it is.
+func (d *dbusConnManager) checkAndReconnect(conn *systemdDbus.Conn, err error) {
+	if !isDbusError(err, errDbusConnClosed) {
+		return
+	}
+	d.resetConnection(conn)
+
+	// Try to reconnect
+	_, err = d.getConnection()
+	if err != nil {
+		logrus.Warnf("Dbus disconnected and failed to reconnect: %s", err)
+	}
+}

--- a/libcontainer/cgroups/systemd/user.go
+++ b/libcontainer/cgroups/systemd/user.go
@@ -17,8 +17,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-// NewUserSystemdDbus creates a connection for systemd user-instance.
-func NewUserSystemdDbus() (*systemdDbus.Conn, error) {
+// newUserSystemdDbus creates a connection for systemd user-instance.
+func newUserSystemdDbus() (*systemdDbus.Conn, error) {
 	addr, err := DetectUserDbusSessionBusAddress()
 	if err != nil {
 		return nil, err

--- a/libcontainer/cgroups/systemd/v1.go
+++ b/libcontainer/cgroups/systemd/v1.go
@@ -70,7 +70,7 @@ var legacySubsystems = subsystemSet{
 	&fs.NameGroup{GroupName: "name=systemd"},
 }
 
-func genV1ResourcesProperties(c *configs.Cgroup, conn *systemdDbus.Conn) ([]systemdDbus.Property, error) {
+func genV1ResourcesProperties(c *configs.Cgroup, cm *dbusConnManager) ([]systemdDbus.Property, error) {
 	var properties []systemdDbus.Property
 	r := c.Resources
 
@@ -90,7 +90,7 @@ func genV1ResourcesProperties(c *configs.Cgroup, conn *systemdDbus.Conn) ([]syst
 			newProp("CPUShares", r.CpuShares))
 	}
 
-	addCpuQuota(conn, &properties, r.CpuQuota, r.CpuPeriod)
+	addCpuQuota(cm, &properties, r.CpuQuota, r.CpuPeriod)
 
 	if r.BlkioWeight != 0 {
 		properties = append(properties,
@@ -169,11 +169,7 @@ func (m *legacyManager) Apply(pid int) error {
 	properties = append(properties,
 		newProp("DefaultDependencies", false))
 
-	dbusConnection, err := m.dbus.getConnection()
-	if err != nil {
-		return err
-	}
-	resourcesProperties, err := genV1ResourcesProperties(c, dbusConnection)
+	resourcesProperties, err := genV1ResourcesProperties(c, m.dbus)
 	if err != nil {
 		return err
 	}
@@ -188,8 +184,7 @@ func (m *legacyManager) Apply(pid int) error {
 		}
 	}
 
-	if err := startUnit(dbusConnection, unitName, properties); err != nil {
-		m.dbus.checkAndReconnect(dbusConnection, err)
+	if err := startUnit(m.dbus, unitName, properties); err != nil {
 		return err
 	}
 
@@ -220,13 +215,7 @@ func (m *legacyManager) Destroy() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	dbusConnection, err := m.dbus.getConnection()
-	if err != nil {
-		return err
-	}
-	unitName := getUnitName(m.cgroups)
-
-	err = stopUnit(dbusConnection, unitName)
+	err := stopUnit(m.dbus, getUnitName(m.cgroups))
 	// Both on success and on error, cleanup all the cgroups we are aware of.
 	// Some of them were created directly by Apply() and are not managed by systemd.
 	if err := cgroups.RemovePaths(m.paths); err != nil {
@@ -377,11 +366,7 @@ func (m *legacyManager) Set(container *configs.Config) error {
 	if m.cgroups.Paths != nil {
 		return nil
 	}
-	dbusConnection, err := m.dbus.getConnection()
-	if err != nil {
-		return err
-	}
-	properties, err := genV1ResourcesProperties(container.Cgroups, dbusConnection)
+	properties, err := genV1ResourcesProperties(container.Cgroups, m.dbus)
 	if err != nil {
 		return err
 	}
@@ -409,8 +394,7 @@ func (m *legacyManager) Set(container *configs.Config) error {
 		}
 	}
 
-	if err := dbusConnection.SetUnitProperties(getUnitName(container.Cgroups), true, properties...); err != nil {
-		m.dbus.checkAndReconnect(dbusConnection, err)
+	if err := setUnitProperties(m.dbus, getUnitName(container.Cgroups), properties...); err != nil {
 		_ = m.Freeze(targetFreezerState)
 		return err
 	}

--- a/libcontainer/cgroups/systemd/v2.go
+++ b/libcontainer/cgroups/systemd/v2.go
@@ -36,7 +36,7 @@ func NewUnifiedManager(config *configs.Cgroup, path string, rootless bool) cgrou
 	}
 }
 
-func genV2ResourcesProperties(c *configs.Cgroup, conn *systemdDbus.Conn) ([]systemdDbus.Property, error) {
+func genV2ResourcesProperties(c *configs.Cgroup, cm *dbusConnManager) ([]systemdDbus.Property, error) {
 	var properties []systemdDbus.Property
 	r := c.Resources
 
@@ -74,7 +74,7 @@ func genV2ResourcesProperties(c *configs.Cgroup, conn *systemdDbus.Conn) ([]syst
 			newProp("CPUWeight", r.CpuWeight))
 	}
 
-	addCpuQuota(conn, &properties, r.CpuQuota, r.CpuPeriod)
+	addCpuQuota(cm, &properties, r.CpuQuota, r.CpuPeriod)
 
 	if r.PidsLimit > 0 || r.PidsLimit == -1 {
 		properties = append(properties,
@@ -138,23 +138,18 @@ func (m *unifiedManager) Apply(pid int) error {
 	properties = append(properties,
 		newProp("DefaultDependencies", false))
 
-	dbusConnection, err := m.dbus.getConnection()
-	if err != nil {
-		return err
-	}
-	resourcesProperties, err := genV2ResourcesProperties(c, dbusConnection)
+	resourcesProperties, err := genV2ResourcesProperties(c, m.dbus)
 	if err != nil {
 		return err
 	}
 	properties = append(properties, resourcesProperties...)
 	properties = append(properties, c.SystemdProps...)
 
-	if err := startUnit(dbusConnection, unitName, properties); err != nil {
-		m.dbus.checkAndReconnect(dbusConnection, err)
+	if err := startUnit(m.dbus, unitName, properties); err != nil {
 		return errors.Wrapf(err, "error while starting unit %q with properties %+v", unitName, properties)
 	}
 
-	if err = m.initPath(); err != nil {
+	if err := m.initPath(); err != nil {
 		return err
 	}
 	if err := fs2.CreateCgroupPath(m.path, m.cgroups); err != nil {
@@ -170,17 +165,13 @@ func (m *unifiedManager) Destroy() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	dbusConnection, err := m.dbus.getConnection()
-	if err != nil {
-		return err
-	}
 	unitName := getUnitName(m.cgroups)
-	if err := stopUnit(dbusConnection, unitName); err != nil {
+	if err := stopUnit(m.dbus, unitName); err != nil {
 		return err
 	}
 
 	// XXX this is probably not needed, systemd should handle it
-	err = os.Remove(m.path)
+	err := os.Remove(m.path)
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
@@ -292,11 +283,7 @@ func (m *unifiedManager) GetStats() (*cgroups.Stats, error) {
 }
 
 func (m *unifiedManager) Set(container *configs.Config) error {
-	dbusConnection, err := m.dbus.getConnection()
-	if err != nil {
-		return err
-	}
-	properties, err := genV2ResourcesProperties(m.cgroups, dbusConnection)
+	properties, err := genV2ResourcesProperties(m.cgroups, m.dbus)
 	if err != nil {
 		return err
 	}
@@ -324,8 +311,7 @@ func (m *unifiedManager) Set(container *configs.Config) error {
 		}
 	}
 
-	if err := dbusConnection.SetUnitProperties(getUnitName(m.cgroups), true, properties...); err != nil {
-		m.dbus.checkAndReconnect(dbusConnection, err)
+	if err := setUnitProperties(m.dbus, getUnitName(m.cgroups), properties...); err != nil {
 		_ = m.Freeze(targetFreezerState)
 		return errors.Wrap(err, "error while setting unit properties")
 	}

--- a/libcontainer/cgroups/systemd/v2.go
+++ b/libcontainer/cgroups/systemd/v2.go
@@ -24,6 +24,7 @@ type unifiedManager struct {
 	// path is like "/sys/fs/cgroup/user.slice/user-1001.slice/session-1.scope"
 	path     string
 	rootless bool
+	dbus     *dbusConnManager
 }
 
 func NewUnifiedManager(config *configs.Cgroup, path string, rootless bool) cgroups.Manager {
@@ -31,6 +32,7 @@ func NewUnifiedManager(config *configs.Cgroup, path string, rootless bool) cgrou
 		cgroups:  config,
 		path:     path,
 		rootless: rootless,
+		dbus:     newDbusConnManager(rootless),
 	}
 }
 
@@ -136,7 +138,7 @@ func (m *unifiedManager) Apply(pid int) error {
 	properties = append(properties,
 		newProp("DefaultDependencies", false))
 
-	dbusConnection, err := getDbusConnection(m.rootless)
+	dbusConnection, err := m.dbus.getConnection()
 	if err != nil {
 		return err
 	}
@@ -148,6 +150,7 @@ func (m *unifiedManager) Apply(pid int) error {
 	properties = append(properties, c.SystemdProps...)
 
 	if err := startUnit(dbusConnection, unitName, properties); err != nil {
+		m.dbus.checkAndReconnect(dbusConnection, err)
 		return errors.Wrapf(err, "error while starting unit %q with properties %+v", unitName, properties)
 	}
 
@@ -167,7 +170,7 @@ func (m *unifiedManager) Destroy() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	dbusConnection, err := getDbusConnection(m.rootless)
+	dbusConnection, err := m.dbus.getConnection()
 	if err != nil {
 		return err
 	}
@@ -206,7 +209,7 @@ func (m *unifiedManager) getSliceFull() (string, error) {
 	}
 
 	if m.rootless {
-		dbusConnection, err := getDbusConnection(m.rootless)
+		dbusConnection, err := m.dbus.getConnection()
 		if err != nil {
 			return "", err
 		}
@@ -289,7 +292,7 @@ func (m *unifiedManager) GetStats() (*cgroups.Stats, error) {
 }
 
 func (m *unifiedManager) Set(container *configs.Config) error {
-	dbusConnection, err := getDbusConnection(m.rootless)
+	dbusConnection, err := m.dbus.getConnection()
 	if err != nil {
 		return err
 	}
@@ -322,6 +325,7 @@ func (m *unifiedManager) Set(container *configs.Config) error {
 	}
 
 	if err := dbusConnection.SetUnitProperties(getUnitName(m.cgroups), true, properties...); err != nil {
+		m.dbus.checkAndReconnect(dbusConnection, err)
 		_ = m.Freeze(targetFreezerState)
 		return errors.Wrap(err, "error while setting unit properties")
 	}

--- a/libcontainer/cgroups/systemd/v2.go
+++ b/libcontainer/cgroups/systemd/v2.go
@@ -200,16 +200,8 @@ func (m *unifiedManager) getSliceFull() (string, error) {
 	}
 
 	if m.rootless {
-		dbusConnection, err := m.dbus.getConnection()
-		if err != nil {
-			return "", err
-		}
-		// managerCGQuoted is typically "/user.slice/user-${uid}.slice/user@${uid}.service" including the quote symbols
-		managerCGQuoted, err := dbusConnection.GetManagerProperty("ControlGroup")
-		if err != nil {
-			return "", err
-		}
-		managerCG, err := strconv.Unquote(managerCGQuoted)
+		// managerCG is typically "/user.slice/user-${uid}.slice/user@${uid}.service".
+		managerCG, err := getManagerProperty(m.dbus, "ControlGroup")
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
This is a backport of upstream PRs

* https://github.com/opencontainers/runc/pull/2923
* https://github.com/opencontainers/runc/pull/2937 (modulo test)
* https://github.com/opencontainers/runc/pull/2997 (modulo test)
* https://github.com/opencontainers/runc/pull/3006

to `release-4.6` branch, to be consumed by cri-o 1.19 in order to fix https://bugzilla.redhat.com/show_bug.cgi?id=1941456.

This also includes backports of
* https://github.com/opencontainers/runc/pull/2614/commits/38447895a54daf52e9ec7670401554ae921a96b3 (PR https://github.com/opencontainers/runc/pull/2614)
* https://github.com/opencontainers/runc/pull/2727/commits/eee425f5a0b4e10f58bf4058e97a6c570583869a (PR https://github.com/opencontainers/runc/pull/2727, first commit only)
mostly to make the merge simpler. 

Original description follows

-----

n case the dbus daemon is ever restarted, the connection is no longer valid and every operation
fails. This is a minor concern for short-lived runc, but much more of a issue in case there is
a long-running daemon (e.g. `cri-o`) is using runc's libcontainer, as the connection is never
retried and the only remedy is to restart the daemon.

The solution to the above is to check the errors returned for `dbus: connection closed by user`
error, and try to re-connect on that. This is what PR #2862 does.

This is a carry of #2862, implementing the idea of retry-in-place (first described
at https://github.com/opencontainers/runc/pull/2862#discussion_r600977482 and https://github.com/opencontainers/runc/pull/2862#discussion_r600975567) on top of what it does.

For more info, see commit messages as well as #2862.

Fixes:
* https://github.com/kubernetes/kubernetes/issues/100328
* https://bugzilla.redhat.com/show_bug.cgi?id=1941456
* https://bugzilla.redhat.com/show_bug.cgi?id=1634092
