### PR TITLE
Bug 1965545: [openshift-4.8] libct/cg/sd: fix dbus error handling

### DIFF
--- a/libcontainer/cgroups/systemd/common.go
+++ b/libcontainer/cgroups/systemd/common.go
@@ -306,7 +306,7 @@ func getUnitName(c *configs.Cgroup) string {
 // isDbusError returns true if the error is a specific dbus error.
 func isDbusError(err error, name string) bool {
 	if err != nil {
-		var derr *dbus.Error
+		var derr dbus.Error
 		if errors.As(err, &derr) {
 			return strings.Contains(derr.Name, name)
 		}


### PR DESCRIPTION
Backport of https://github.com/opencontainers/runc/pull/2997. Original description follows.

----

This fixes isDbusError function, introduced by commit bacfc2c. Due to a
type error it was not working at all.

This also fixes the whole "retry on dbus disconnect" logic.

This also fixes a regression in startUnit (and cgroupManager.Apply()),
which should never return "unit already exists" error but it did.

Fixes: bacfc2c
Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>

----

(cherry picked from commit b2d28c5df2c34c987b, modulo test)
Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>